### PR TITLE
Update constant.ts

### DIFF
--- a/src/grid/base/constant.ts
+++ b/src/grid/base/constant.ts
@@ -261,7 +261,7 @@ export const freezeRender: string = 'freezerender';
 /** @hidden */
 export const contextMenuOpen: string = 'contextMenuOpen';
 /** @hidden */
-export const columnMenuClick: string = 'contextMenuClick';
+export const columnMenuClick: string = 'columnMenuClick';
 /** @hidden */
 export const columnMenuOpen: string = 'columnMenuOpen';
 /** @hidden */


### PR DESCRIPTION
I found that two different constants have the same value: contextMenuClick and columnMenuClick. This is the reason for a bug when the user tries to work with the click on the column menu item event emitter. I just edited columnMenuClick constant and set the value to 'columnMenuClick' as it should be.